### PR TITLE
Added PlantProfileResponses based on retrieved data

### DIFF
--- a/sunnyportal/responses.py
+++ b/sunnyportal/responses.py
@@ -124,7 +124,6 @@ class PlantProfileResponse(ResponseBase):
     def parse(self, data):
         tag = super().parse(data)
 
-
         self.name = tag.find('name').text
         self.peak_power = self.kwp_to_wp(float(tag.find('peak-power').text))
         self.city_country = tag.find('city-country').text
@@ -132,7 +131,7 @@ class PlantProfileResponse(ResponseBase):
 
         description = tag.find('description')
         if description is not None:
-            self.description = tag.find('description').text.replace('<br />', '\n')
+            self.description = tag.find('description').text.replace('<br />', '')
         else:
             self.description = None
 

--- a/sunnyportal/responses.py
+++ b/sunnyportal/responses.py
@@ -120,7 +120,55 @@ class PlantListResponse(ResponseBase):
 class PlantProfileResponse(ResponseBase):
     def parse(self, data):
         tag = super().parse(data)
-        # TODO: parse into something meaningful
+
+        name = tag.find('name')
+        self.name = name.text
+        self.name_type = name.attrib['name']
+
+        peak_power = tag.find('peak-power')
+        self.peak_power_name = peak_power.attrib['name']
+        self.peak_power_unit = peak_power.attrib['unit']
+        self.peak_power = peak_power.text
+
+        city_country = tag.find('city-country')
+        self.city_country_name = city_country.attrib['name']
+        self.city_country = city_country.text
+
+        start_date = tag.find('start-date')
+        self.start_date_name = start_date.attrib['name']
+        self.start_date = datetime.strptime(start_date.text, "%d/%m/%Y")
+
+        plant_image = tag.find('plant-image')
+        self.plant_image_name = plant_image.attrib['name']
+        self.plant_image_height = plant_image.attrib['height']
+        self.plant_image_width = plant_image.attrib['width']
+        self.plant_image = plant_image.text
+
+        self.production_data = []
+        for channel in tag.find('production-data').findall('channel'):
+            name = channel.attrib['name']
+            meta_name = channel.attrib['meta-name']
+            unit = channel.attrib['unit']
+            text = channel.text
+            self.production_data.append({'name': name, 'meta-name': meta_name, 'unit': unit, 'text': text})
+
+        self.inverters = []
+        inverters = tag.find('inverters')
+        inverters_name = inverters.attrib['name']
+        for inverter in inverters.findall('inverter'):
+            count = int(inverter.attrib['count'])
+            deviceIcon = inverter.attrib['deviceIcon']
+            text = inverter.text
+            self.production_data.append({'name': inverters_name, 'count': count, 'deviceIcon': deviceIcon, 'text': text})
+
+        self.communicationProducts = []
+        communicationProducts = tag.find('communicationProducts')
+        communicationProducts_name = communicationProducts.attrib['name']
+        for communicationProduct in communicationProducts.findall('communicationProduct'):
+            count = int(communicationProduct.attrib['count'])
+            deviceIcon = communicationProduct.attrib['deviceIcon']
+            text = communicationProduct.text
+            self.communicationProducts.append({'name': communicationProducts_name, 'count': count, 'deviceIcon': deviceIcon, 'text': text})
 
 
 class DataResponse(ResponseBase):


### PR DESCRIPTION
 * plant name
    - PV System Name
        + plant.profile().name_type
    - Plant name
        + plant.profile().name
 * peak-power
    - peak power value
        + plant.profile().peak_power
    - PV system power
        + plant.profile().peak_power_name
    - peak power units
        + plant.profile().peak_power_unit
 * city-country
    - Plant location
        + plant.profile().city_country
    - Location
        + plant.profile().city_country_name
 * start-date
    - plant.profile().start_date
    - plant.profile().start_date_name
 * plant-image
    - image url
        + plant.profile().plant_image
    - image name
        + plant.profile().plant_image_name
    - image width
        + plant.profile().plant_image_width
    - image height
        + plant.profile().plant_image_height
 * production-data (list of dictionaries)
    - name
        + plant.profile().production_data['name']
    - meta-name
        + plant.profile().production_data['meta-name']
    - unit
        + plant.profile().production_data['unit']
    - text
        + plant.profile().production_data['text']
 * inverters (list of dictionaries)
    - tag (Inverter)
        + plant.profile().inverters['name']
    - count
        + plant.profile().inverters['count']
    - deviceIcon url
        + plant.profile().inverters['deviceIcon']
    - name
        + plant.profile().inverters['text']
 * communicationProducts (list of dictionaries)
   - tag (Communication)
       + plant.profile().communicationProducts['name']
    - count
       + plant.profile().communicationProducts['count']
    - deviceIcon url
       + plant.profile().communicationProducts['deviceIcon']
    - name
       + plant.profile().communicationProducts['text']